### PR TITLE
Add build depend on ros_environment

### DIFF
--- a/ws281x/package.xml
+++ b/ws281x/package.xml
@@ -33,6 +33,7 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>ros_environment</build_depend>
   <build_depend>roscpp</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <exec_depend>roscpp</exec_depend>


### PR DESCRIPTION
To have `ROS_DISTRO` variable available when generating the postinst script.

Attempt to fix https://github.com/CopterExpress/ros_led/issues/1